### PR TITLE
Fixed layer crash issues and removed deprecated enum value.

### DIFF
--- a/src/command.cc
+++ b/src/command.cc
@@ -336,7 +336,7 @@ class CommandBufferInternalState {
 
  private:
   static constexpr int kNumBindPoints =
-      VK_PIPELINE_BIND_POINT_RANGE_SIZE;  // graphics, compute
+      /*VK_PIPELINE_BIND_POINT_RANGE_SIZE=*/2;  // graphics, compute
 
   Device* device_;
   std::array<const Pipeline*, kNumBindPoints> bound_pipelines_;

--- a/src/command_pool.cc
+++ b/src/command_pool.cc
@@ -46,12 +46,17 @@ void CommandPool::AllocateCommandBuffers(
 void CommandPool::FreeCommandBuffers(uint32_t command_buffer_count,
                                      const VkCommandBuffer* p_command_buffers) {
   for (uint32_t i = 0; i < command_buffer_count; ++i) {
-    primary_command_buffers_.erase(std::find(primary_command_buffers_.begin(),
-                                             primary_command_buffers_.end(),
-                                             p_command_buffers[i]));
-    secondary_command_buffers_.erase(
-        std::find(secondary_command_buffers_.begin(),
-                  secondary_command_buffers_.end(), p_command_buffers[i]));
+    std::vector<VkCommandBuffer>::iterator it = std::find(primary_command_buffers_.begin(),
+                                                          primary_command_buffers_.end(),
+                                                          p_command_buffers[i]);
+    if (it != primary_command_buffers_.end()) {
+      primary_command_buffers_.erase(it);
+    }
+    it = std::find(secondary_command_buffers_.begin(),
+                   secondary_command_buffers_.end(), p_command_buffers[i]);
+    if (it != secondary_command_buffers_.end()) {
+      secondary_command_buffers_.erase(it);
+    }
   }
 }
 

--- a/src/gfr.cc
+++ b/src/gfr.cc
@@ -404,6 +404,9 @@ const VkDeviceCreateInfo* GfrContext::GetModifiedDeviceCreateInfo(
                           pCreateInfo->ppEnabledExtensionNames +
                               pCreateInfo->enabledExtensionCount);
 
+  UniqueCStringArray original_extension_names = std::make_unique<CStringArray>();
+  *original_extension_names = *extension_names;
+
   if (!requested_buffer_marker) {
     // Get available extensions and add buffer marker if possible
     bool has_buffer_marker = false;
@@ -470,6 +473,10 @@ const VkDeviceCreateInfo* GfrContext::GetModifiedDeviceCreateInfo(
 
   auto device_create_info = std::make_unique<DeviceCreateInfo>();
   device_create_info->original_create_info = *pCreateInfo;
+  device_create_info->original_create_info.enabledExtensionCount =
+      static_cast<uint32_t>(original_extension_names->size());
+  device_create_info->original_create_info.ppEnabledExtensionNames =
+      original_extension_names->data();
   device_create_info->modified_create_info = *pCreateInfo;
   device_create_info->modified_create_info.enabledExtensionCount =
       static_cast<uint32_t>(extension_names->size());
@@ -484,6 +491,7 @@ const VkDeviceCreateInfo* GfrContext::GetModifiedDeviceCreateInfo(
 
   // Store the extension names
   device_extension_names_.push_back(std::move(extension_names));
+  device_extension_names_.push_back(std::move(original_extension_names));
 
   return p_modified_create_info;
 }


### PR DESCRIPTION
The enum value `VK_PIPELINE_BIND_POINT_RANGE_SIZE` is deprecated in vulkan-headers v1.2.140. This causes a compiler error when using a newer version of the Vulkan headers.
When freeing individual command buffers from command pools, a crash will occur if any of the command buffers being freed is not in the primary buffer vector or the secondary buffer vector.
The list of device extension names used when creating a logical device might be freed after `vkCreateDevice` but before debug information is flushed to a file/console.